### PR TITLE
Support `gap` property

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -316,6 +316,33 @@ describe("Flexbox", () => {
     });
   });
 
+
+  describe("gap", () => {
+    describe("gap", () => {
+      test.each(spacing)("%s", (key, value) => {
+        expect(tw(`gap-${key}`)).toEqual({
+          gap: value,
+        });
+      });
+    });
+
+    describe("gap-x", () => {
+      test.each(spacing)("%s", (key, value) => {
+        expect(tw(`gap-x-${key}`)).toEqual({
+          columnGap: value,
+        });
+      });
+    });
+
+    describe("gap-y", () => {
+      test.each(spacing)("%s", (key, value) => {
+        expect(tw(`gap-y-${key}`)).toEqual({
+          rowGap: value,
+        });
+      });
+    });
+  });
+
   describe("flex-grow", () => {
     test.each([
       ["grow", 1],

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,9 @@ const utilityPatterns: Record<string, string | [string, string | string[]]> = {
   // Flexbox
   basis: "flexBasis",
   flex: "flex",
+  gap: "gap",
+  "gap-x": ["gap", "columnGap"],
+  "gap-y": ["gap", "rowGap"],
   grow: "flexGrow",
   shrink: "flexShrink",
   order: "order",


### PR DESCRIPTION
👋 really enjoying using this project!

I noticed that @react-pdf/renderer@3.1.0 recently [added support for the `gap` property](https://github.com/diegomura/react-pdf/pull/2160), so I implemented basic support for this package, including [`gap-x` and `gap-y` variants](https://tailwindcss.com/docs/gap). Seems to behave the same as other spacing utilities like `mr`.

Happy to make any changes - thanks!